### PR TITLE
isLoggedIn & using setEndPoint to update endPoint

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,15 +7,12 @@ var request = require('request')
 	, token = undefined
 	;
 
-function setEndPoint(env) {
-	if ( env === 'production' ) {
-		endPoint = 'https://api4.liverail.com'
-	} else {
-		endPoint = 'https://api4.int.liverail.com'
-	}
+function setEndPoint(endPoint) {
+	endPoint = endPoint;
 }
 
 liverail.setEndPoint = setEndPoint;
+liverail.isLoggedIn = token === undefined ? false : true;
 
 liverail.login = function (user, pass, callback) {
 	var parser = new xml2js.Parser();
@@ -72,4 +69,8 @@ liverail.call = function () {
 	});
 };
 
-setEndPoint(process.env.NODE_ENV);
+if (process.env.NODE_ENV === 'production') {
+	setEndPoint('https://api4.liverail.com');
+} else {
+	setEndPoint('https://api4.int.liverail.com');
+}


### PR DESCRIPTION
Just two simple QOL changes.

isLoggedIn checks if we have a token and returns true if we do so a caller can check that rather than logging in every time.

setEndpoint will now set the endpoint used by the library that you pass in. Functionality to set to the production endpoint still happens so that it's backwards compatible with other implementations.
